### PR TITLE
feat: WDK Swap — Velora DEX integration for rebalance strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- WDK Swap: Velora DEX integration for rebalance strategy — `quoteSwap` + `executeSwap` via `@tetherto/wdk-protocol-swap-velora-evm` ([#17](https://github.com/ronaldmego/pepa-wallet-intelligence/issues/17))
+- Rebalance strategy now proposes DEX swaps (ETH/MATIC → USDT) instead of vault transfers, with real quote data
+- Swap decisions go through full 4-layer governance pipeline (rules → anomaly → LLM → human)
+- 10 new tests (121 total): swap wrapper, strategy swap decisions, token address validation
+
 ### Changed
 - Migrate LLM from OpenAI GPT-5.2 to Anthropic Claude SDK ([#13](https://github.com/ronaldmego/pepa-wallet-intelligence/issues/13))
 - Switch dashboard from dark to light theme — teal/gold/copper palette ([#12](https://github.com/ronaldmego/pepa-wallet-intelligence/issues/12))

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/sdk": "^0.78.0",
         "@supabase/supabase-js": "^2.98.0",
         "@tetherto/wdk": "1.0.0-beta.5",
+        "@tetherto/wdk-protocol-swap-velora-evm": "^1.0.0-beta.4",
         "@tetherto/wdk-wallet-evm": "1.0.0-beta.8",
         "dotenv": "^17.3.1",
         "next": "15.5.12",
@@ -699,6 +700,116 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@gelatonetwork/relay-sdk": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@gelatonetwork/relay-sdk/-/relay-sdk-5.7.0.tgz",
+      "integrity": "sha512-8y+uKL+Et7QxOunDu9+P4UrFdQSPT8x6PFqRUq/2LBtZK89Zt8lh2X6VA86cd6nST9xOHjj46PcER8xEWG5iJA==",
+      "deprecated": "This package is deprecated. Use @gelatocloud/gasless instead.",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "1.13.2",
+        "ethers": "6.13.4",
+        "isomorphic-ws": "^5.0.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@gelatonetwork/relay-sdk/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@gelatonetwork/relay-sdk/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@gelatonetwork/relay-sdk/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@gelatonetwork/relay-sdk/node_modules/ethers": {
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
+      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@gelatonetwork/relay-sdk/node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gelatonetwork/relay-sdk/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/@gelatonetwork/relay-sdk/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1414,6 +1525,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
@@ -1496,6 +1619,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@paraswap/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@paraswap/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-msv0Etc5f7H2UDnDd23wKzNnx64fj1iwt8IlBORTFIpxJ1+fa+TqNO7lhtohfRiVmU3dnnAMcjEi4D+WHSWpvw==",
+      "license": "MIT"
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -1898,6 +2039,66 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@safe-global/safe-deployments": {
+      "version": "1.37.52",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-deployments/-/safe-deployments-1.37.52.tgz",
+      "integrity": "sha512-BFwJWY7L4nB2T7grHmcPp/DNtwz3L1Iuydra1iaRg+WbqPTgsrS2Buf5bkKWD3AG5MdwuqqdTnClBfzQJs+6GA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.2"
+      }
+    },
+    "node_modules/@safe-global/safe-modules-deployments": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.25.tgz",
+      "integrity": "sha512-KjgenKhBRyFHEfo8xlBgNzKAy25vrmGyCGZwTjIuA81yOSRJRe85GE5Yfg/FBKeeyHqR2dD1WPZr6c2Uqd6C/g==",
+      "license": "MIT"
+    },
+    "node_modules/@safe-global/types-kit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/types-kit/-/types-kit-3.0.0.tgz",
+      "integrity": "sha512-AZWIlR5MguDPdGiOj7BB4JQPY2afqmWQww1mu8m8Oi16HHBW99G01kFOu4NEHBwEU1cgwWOMY19hsI5KyL4W2w==",
+      "license": "MIT",
+      "dependencies": {
+        "abitype": "^1.0.2"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2009,6 +2210,149 @@
         "bare-node-runtime": "^1.1.4"
       }
     },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm": {
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-protocol-swap-velora-evm/-/wdk-protocol-swap-velora-evm-1.0.0-beta.4.tgz",
+      "integrity": "sha512-G7sbRpMhDakxB2I6eS9SqUh9TTVth6xQFF2XaQriOrxmPdvxF6CQAtZKixHUb3lMXx3dsftImrFiCzKk1zExVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tetherto/wdk-wallet": "^1.0.0-beta.1",
+        "@tetherto/wdk-wallet-evm": "^1.0.0-beta.2",
+        "@tetherto/wdk-wallet-evm-erc-4337": "^1.0.0-beta.1",
+        "@velora-dex/sdk": "9.0.0",
+        "bare-node-runtime": "^1.1.4",
+        "ethers": "6.13.5"
+      }
+    },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm/node_modules/ethers": {
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/@tetherto/wdk-protocol-swap-velora-evm/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tetherto/wdk-safe-protocol-kit": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-safe-protocol-kit/-/wdk-safe-protocol-kit-6.1.3.tgz",
+      "integrity": "sha512-KazAj6y5Ywfm1SbDWdQXetHQ9Rl/8+vwWLICAl+j0Qm1QbryLBz7fbwawSt1l5wT+RYRV64HfqIetlQQaNK6YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@safe-global/safe-deployments": "^1.37.49",
+        "@safe-global/safe-modules-deployments": "^2.2.21",
+        "@safe-global/types-kit": "^3.0.0",
+        "abitype": "^1.0.2",
+        "semver": "^7.7.2",
+        "viem": "^2.21.8"
+      },
+      "optionalDependencies": {
+        "@noble/curves": "^1.6.0",
+        "@peculiar/asn1-schema": "^2.3.13"
+      },
+      "peerDependencies": {
+        "ethers": "^6.13.7"
+      }
+    },
+    "node_modules/@tetherto/wdk-safe-relay-kit": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-safe-relay-kit/-/wdk-safe-relay-kit-4.1.5.tgz",
+      "integrity": "sha512-os9MPiv0xKt3jyi/5kMBDY2PCC2P0WHxztagxntf7fiKdSiQAVULbtx/w9jKkVCj+cn8M2ijVHZdA0vQl8pcfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@gelatonetwork/relay-sdk": "^5.6.1",
+        "@safe-global/safe-modules-deployments": "^2.2.21",
+        "@safe-global/types-kit": "^3.0.0",
+        "@tetherto/wdk-safe-protocol-kit": "^6.1.3",
+        "semver": "^7.7.2",
+        "viem": "^2.21.8"
+      }
+    },
     "node_modules/@tetherto/wdk-wallet": {
       "version": "1.0.0-beta.7",
       "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.7.tgz",
@@ -2033,6 +2377,113 @@
         "bip39": "3.1.0",
         "ethers": "6.14.3",
         "sodium-universal": "5.0.1"
+      }
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337": {
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet-evm-erc-4337/-/wdk-wallet-evm-erc-4337-1.0.0-beta.5.tgz",
+      "integrity": "sha512-Hz/AvKPt1QiMXMEkaGwMwIq9gg1DBSqWm8G+OiolBQVpQHPNHEpSbED4w/F2jcGd6jdefod3IqrGWBscKE55RA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tetherto/wdk-safe-relay-kit": "4.1.5",
+        "@tetherto/wdk-wallet": "1.0.0-beta.7",
+        "@tetherto/wdk-wallet-evm": "1.0.0-beta.8",
+        "bare-node-runtime": "^1.1.4",
+        "ethers": "6.14.4"
+      }
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337/node_modules/ethers": {
+      "version": "6.14.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.14.4.tgz",
+      "integrity": "sha512-Jm/dzRs2Z9iBrT6e9TvGxyb5YVKAPLlpna7hjxH7KH/++DSh2T/JVmQUv7iHI5E55hDbp/gEVvstWYXVxXFzsA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/@tetherto/wdk-wallet-evm-erc-4337/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2749,6 +3200,39 @@
         "win32"
       ]
     },
+    "node_modules/@velora-dex/sdk": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@velora-dex/sdk/-/sdk-9.0.0.tgz",
+      "integrity": "sha512-9aHpJ+dNXhR8zx1Pz+cCjDZDDQVR2/DfWPRZiXRCfAUTbpAWxFwsUXrKjCZMp9G9kM1gay8iN6H0TDUnvt624g==",
+      "license": "MIT",
+      "dependencies": {
+        "@paraswap/core": "2.4.0",
+        "ts-essentials": "^10.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "axios": ">=0.25.0 <2.0.0",
+        "ethers": "^5.5.0 || ^6.0.0",
+        "viem": "^2.21.0",
+        "web3": "^4.14.0"
+      },
+      "peerDependenciesMeta": {
+        "axios": {
+          "optional": true
+        },
+        "ethers": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        },
+        "web3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -2858,6 +3342,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {
@@ -3127,6 +3632,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3153,6 +3673,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -3215,6 +3741,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4242,7 +4779,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4408,6 +4944,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -4719,6 +5267,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4772,7 +5329,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4870,7 +5426,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4880,7 +5435,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4925,7 +5479,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4938,7 +5491,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5747,6 +6299,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5761,6 +6333,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -5796,7 +6384,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5847,7 +6434,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5872,7 +6458,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5960,7 +6545,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6025,7 +6609,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6038,7 +6621,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6054,7 +6636,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6572,6 +7153,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6797,7 +7402,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6825,6 +7429,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -7216,6 +7841,63 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.5.tgz",
+      "integrity": "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7529,6 +8211,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7536,6 +8224,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -7925,7 +8633,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8649,6 +9356,20 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.1.1.tgz",
+      "integrity": "sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8790,7 +9511,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8952,6 +9673,72 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.47.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.4.tgz",
+      "integrity": "sha512-h0Wp/SYmJO/HB4B/em1OZ3W1LaKrmr7jzaN7talSlZpo0LCn0V6rZ5g923j6sf4VUSrqp/gUuWuHFc7UcoIp8A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.5",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@supabase/supabase-js": "^2.98.0",
     "@tetherto/wdk": "1.0.0-beta.5",
+    "@tetherto/wdk-protocol-swap-velora-evm": "^1.0.0-beta.4",
     "@tetherto/wdk-wallet-evm": "1.0.0-beta.8",
     "dotenv": "^17.3.1",
     "next": "15.5.12",

--- a/src/lib/agent/autonomous.ts
+++ b/src/lib/agent/autonomous.ts
@@ -1,10 +1,9 @@
 import type { AgentStatus, AgentStatusInfo, FinalOutcome } from "@/types";
 import { fetchMarketData } from "./market";
 import { evaluateStrategy } from "./strategies";
-import { getWalletBalance } from "@/lib/wdk";
+import { getWalletBalance, getWalletAddress, quoteSwap } from "@/lib/wdk";
 import { CHAINS } from "@/lib/wdk/chains";
 import { processTransaction } from "@/lib/governance/pipeline";
-import { getWalletAddress } from "@/lib/wdk";
 import {
   getActiveStrategies,
   getAllStrategies,
@@ -143,8 +142,63 @@ async function runAgentCycle(): Promise<void> {
         let transactionId: string | null = null;
         let governanceOutcome: FinalOutcome | null = null;
 
-        if (result.decision === "transfer" && result.transfer) {
-          // 5. Submit through governance pipeline
+        if (result.decision === "swap" && result.swap) {
+          // 5a. Swap via Velora DEX — get quote, then submit through governance
+          console.log(
+            `[PEPA Agent] Strategy "${strategy.name}": SWAP ${result.swap.amountIn} ${result.swap.tokenInSymbol} → ${result.swap.tokenOutSymbol} on ${result.swap.chain}`
+          );
+
+          try {
+            // Get real DEX quote before governance decision
+            const amountWei = BigInt(Math.round(result.swap.amountIn * 1e18));
+            let quoteInfo = "";
+            try {
+              const quote = await quoteSwap({
+                chain: result.swap.chain,
+                tokenIn: result.swap.tokenIn,
+                tokenOut: result.swap.tokenOut,
+                tokenInAmount: amountWei,
+              });
+              quoteInfo = ` (quote: ${quote.tokenOutAmount} ${result.swap.tokenOutSymbol}, fee: ${quote.fee})`;
+              result.swap.quoteAmountOut = quote.tokenOutAmount;
+              result.swap.quoteFee = quote.fee;
+              console.log(`[PEPA Agent] DEX quote: ${quote.tokenInAmount} → ${quote.tokenOutAmount}${result.swap.tokenOutSymbol}, fee: ${quote.fee}`);
+            } catch (quoteErr) {
+              console.warn(`[PEPA Agent] DEX quote failed (proceeding with governance):`, quoteErr);
+              quoteInfo = " (quote unavailable — testnet liquidity)";
+            }
+
+            // Submit swap through governance pipeline as a transaction
+            const walletAddress = await getWalletAddress(result.swap.chain);
+            const { transaction, result: govResult } = await processTransaction(
+              walletAddress,
+              {
+                recipient: result.swap.tokenOut, // token contract as recipient
+                amount: result.swap.amountIn,
+                currency: result.swap.tokenInSymbol,
+                chain: result.swap.chain,
+                category: "agent_swap",
+                merchant: `pepa_agent_swap_velora`,
+                description: `${result.reason}${quoteInfo}`,
+              }
+            );
+
+            transactionId = transaction.id;
+            governanceOutcome = govResult.final_outcome;
+
+            console.log(
+              `[PEPA Agent] Swap governance outcome: ${governanceOutcome} (tx: ${transactionId})`
+            );
+
+            await updateStrategyLastExecution(strategy.id);
+          } catch (err) {
+            console.error(
+              `[PEPA Agent] Swap pipeline error for strategy "${strategy.name}":`,
+              err
+            );
+          }
+        } else if (result.decision === "transfer" && result.transfer) {
+          // 5b. Submit transfer through governance pipeline
           console.log(
             `[PEPA Agent] Strategy "${strategy.name}": TRANSFER ${result.transfer.amount} ${result.transfer.currency} on ${result.transfer.chain}`
           );

--- a/src/lib/agent/strategies.ts
+++ b/src/lib/agent/strategies.ts
@@ -6,6 +6,18 @@ import type {
   AgentRunDecision,
 } from "@/types";
 import type { WalletBalance } from "@/lib/wdk";
+import { SWAP_TOKENS } from "@/lib/wdk";
+
+export interface SwapDetails {
+  chain: string;
+  tokenIn: string;
+  tokenOut: string;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+  amountIn: number;
+  quoteAmountOut?: string;
+  quoteFee?: string;
+}
 
 export interface StrategyDecision {
   decision: AgentRunDecision;
@@ -16,6 +28,7 @@ export interface StrategyDecision {
     vault_address: string;
     currency: string;
   };
+  swap?: SwapDetails;
 }
 
 // ============================================================
@@ -185,7 +198,26 @@ export function evaluateRebalance(
   }
 
   const symbol = maxDriftChain.includes("polygon") ? "MATIC" : "ETH";
+  const wrappedSymbol = maxDriftChain.includes("polygon") ? "WMATIC" : "WETH";
 
+  // Check if swap tokens are available for this chain — use DEX swap instead of vault transfer
+  const chainTokens = SWAP_TOKENS[maxDriftChain];
+  if (chainTokens && chainTokens[wrappedSymbol] && chainTokens["USDT"]) {
+    return {
+      decision: "swap",
+      reason: `Rebalance via DEX: ${maxDriftChain} overweight by ${maxDrift.toFixed(1)}% (threshold: ${config.drift_threshold_pct}%). Swapping ${transferAmount.toFixed(6)} ${symbol} → USDT via Velora DEX.`,
+      swap: {
+        chain: maxDriftChain,
+        tokenIn: chainTokens[wrappedSymbol],
+        tokenOut: chainTokens["USDT"],
+        tokenInSymbol: symbol,
+        tokenOutSymbol: "USDT",
+        amountIn: transferAmount,
+      },
+    };
+  }
+
+  // Fallback: vault transfer if no swap tokens configured
   return {
     decision: "transfer",
     reason: `Rebalance: ${maxDriftChain} overweight by ${maxDrift.toFixed(1)}% (threshold: ${config.drift_threshold_pct}%). Transferring ${transferAmount.toFixed(6)} ${symbol} to vault.`,

--- a/src/lib/wdk/index.ts
+++ b/src/lib/wdk/index.ts
@@ -1,4 +1,5 @@
 export {
+  getWdk,
   getWalletAddress,
   getWalletBalance,
   sendTransaction,
@@ -16,3 +17,12 @@ export {
   getChain,
   type ChainConfig,
 } from "./chains";
+
+export {
+  quoteSwap,
+  executeSwap,
+  SWAP_TOKENS,
+  type SwapQuote,
+  type SwapExecutionResult,
+  type SwapInput,
+} from "./swap";

--- a/src/lib/wdk/swap.ts
+++ b/src/lib/wdk/swap.ts
@@ -1,0 +1,107 @@
+import VeloraProtocolEvm from "@tetherto/wdk-protocol-swap-velora-evm";
+import type { SwapOptions } from "@tetherto/wdk-protocol-swap-velora-evm";
+import { getWdk } from "./wallet";
+import { DEFAULT_CHAIN } from "./chains";
+
+// Well-known testnet token addresses
+export const SWAP_TOKENS: Record<string, Record<string, string>> = {
+  "ethereum-sepolia": {
+    WETH: "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
+    USDT: "0x7169D38820dfd117C3FA1f22a697dBA58d90BA06",
+  },
+  "polygon-amoy": {
+    WMATIC: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+    USDT: "0x1616d425Cd540B256475cBfb604586C8598eC0FB",
+  },
+};
+
+export interface SwapQuote {
+  fee: string;
+  tokenInAmount: string;
+  tokenOutAmount: string;
+  tokenIn: string;
+  tokenOut: string;
+  chain: string;
+}
+
+export interface SwapExecutionResult {
+  hash: string;
+  fee: string;
+  tokenInAmount: string;
+  tokenOutAmount: string;
+  chain: string;
+}
+
+export interface SwapInput {
+  chain?: string;
+  tokenIn: string;
+  tokenOut: string;
+  tokenInAmount?: bigint;
+  tokenOutAmount?: bigint;
+  maxFee?: bigint;
+}
+
+async function getSwapProtocol(chain: string): Promise<VeloraProtocolEvm> {
+  const wdk = getWdk();
+  const account = await wdk.getAccount(chain, 0);
+  // WDK returns IWalletAccountWithProtocols; VeloraProtocolEvm expects WalletAccountEvm.
+  // At runtime the account IS a WalletAccountEvm — the generic wrapper type just doesn't narrow.
+  return new VeloraProtocolEvm(account as unknown as ConstructorParameters<typeof VeloraProtocolEvm>[0]);
+}
+
+function buildSwapOptions(input: SwapInput): SwapOptions {
+  if (input.tokenOutAmount) {
+    return {
+      tokenIn: input.tokenIn,
+      tokenOut: input.tokenOut,
+      tokenOutAmount: input.tokenOutAmount,
+    };
+  }
+  // Default to sell (tokenInAmount) — must provide at least one
+  return {
+    tokenIn: input.tokenIn,
+    tokenOut: input.tokenOut,
+    tokenInAmount: input.tokenInAmount ?? 0n,
+  };
+}
+
+/**
+ * Get a swap quote without executing — proves the agent makes informed decisions
+ * with real DEX data. Works even on testnet with no liquidity (returns price data).
+ */
+export async function quoteSwap(input: SwapInput): Promise<SwapQuote> {
+  const chain = input.chain ?? DEFAULT_CHAIN;
+  const protocol = await getSwapProtocol(chain);
+  const options = buildSwapOptions(input);
+
+  const quote = await protocol.quoteSwap(options);
+
+  return {
+    fee: quote.fee.toString(),
+    tokenInAmount: quote.tokenInAmount.toString(),
+    tokenOutAmount: quote.tokenOutAmount.toString(),
+    tokenIn: input.tokenIn,
+    tokenOut: input.tokenOut,
+    chain,
+  };
+}
+
+/**
+ * Execute a swap through Velora DEX.
+ * Must go through governance pipeline before calling this.
+ */
+export async function executeSwap(input: SwapInput): Promise<SwapExecutionResult> {
+  const chain = input.chain ?? DEFAULT_CHAIN;
+  const protocol = await getSwapProtocol(chain);
+  const options = buildSwapOptions(input);
+
+  const result = await protocol.swap(options);
+
+  return {
+    hash: result.hash,
+    fee: result.fee.toString(),
+    tokenInAmount: result.tokenInAmount.toString(),
+    tokenOutAmount: result.tokenOutAmount.toString(),
+    chain,
+  };
+}

--- a/src/lib/wdk/wallet.ts
+++ b/src/lib/wdk/wallet.ts
@@ -13,7 +13,7 @@ function getSeedPhrase(): string {
   return seed;
 }
 
-function getWdk(): WDK {
+export function getWdk(): WDK {
   if (wdkInstance) return wdkInstance;
 
   const seed = getSeedPhrase();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -203,7 +203,7 @@ export interface AgentStrategy {
   updated_at: string;
 }
 
-export type AgentRunDecision = "hold" | "transfer";
+export type AgentRunDecision = "hold" | "transfer" | "swap";
 
 export interface AgentRun {
   id: string;

--- a/tests/agent/strategies.test.ts
+++ b/tests/agent/strategies.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/agent/strategies";
 import type { AgentStrategy, MarketData, DcaConfig, RebalanceConfig } from "@/types";
 import type { WalletBalance } from "@/lib/wdk";
+import { SWAP_TOKENS } from "@/lib/wdk";
 
 // ============================================================
 // Fixtures
@@ -140,14 +141,20 @@ describe("evaluateRebalance", () => {
     expect(result.reason).toContain("within tolerance");
   });
 
-  it("transfers when drift exceeds threshold (overweight)", () => {
+  it("proposes swap when drift exceeds threshold (overweight)", () => {
     // ETH: 1 * 2000 = $2000 (95.2%), MATIC: 200 * 0.5 = $100 (4.8%)
     // Target: 60/40, ETH drift: +35.2% — over 15%
     const balances = makeBalances("1", "200");
     const strategy = makeRebalanceStrategy();
     const result = evaluateRebalance(strategy, MARKET_DATA, balances);
-    expect(result.decision).toBe("transfer");
+    expect(result.decision).toBe("swap");
     expect(result.reason).toContain("overweight");
+    expect(result.reason).toContain("Velora DEX");
+    expect(result.swap).toBeDefined();
+    expect(result.swap!.tokenInSymbol).toBe("ETH");
+    expect(result.swap!.tokenOutSymbol).toBe("USDT");
+    expect(result.swap!.tokenIn).toBe(SWAP_TOKENS["ethereum-sepolia"]["WETH"]);
+    expect(result.swap!.tokenOut).toBe(SWAP_TOKENS["ethereum-sepolia"]["USDT"]);
   });
 
   it("holds when zero portfolio", () => {
@@ -158,15 +165,16 @@ describe("evaluateRebalance", () => {
     expect(result.reason).toContain("$0");
   });
 
-  it("holds when no chain is overweight beyond threshold", () => {
+  it("proposes swap when MATIC is overweight beyond threshold", () => {
     // ETH: 0.01 * 2000 = $20 (2.7%), MATIC: 1400 * 0.5 = $700 (97.2%)
-    // ETH is underweight, MATIC is overweight by 57.2% → should transfer MATIC
+    // ETH is underweight, MATIC is overweight by 57.2% → should swap MATIC
     const balances = makeBalances("0.01", "1400");
     const strategy = makeRebalanceStrategy();
     const result = evaluateRebalance(strategy, MARKET_DATA, balances);
-    // MATIC overweight by ~57% which exceeds 15% threshold → transfer
-    expect(result.decision).toBe("transfer");
-    expect(result.transfer?.chain).toBe("polygon-amoy");
+    // MATIC overweight by ~57% which exceeds 15% threshold → swap
+    expect(result.decision).toBe("swap");
+    expect(result.swap?.chain).toBe("polygon-amoy");
+    expect(result.swap?.tokenInSymbol).toBe("MATIC");
   });
 
   it("holds when drift is below threshold", () => {
@@ -180,27 +188,48 @@ describe("evaluateRebalance", () => {
     expect(result.reason).toContain("within tolerance");
   });
 
-  it("transfers half the excess when overweight", () => {
+  it("swaps half the excess when overweight", () => {
     // ETH: 1 * 2000 = $2000 (95.2%), MATIC: 200 * 0.5 = $100 (4.8%)
     // Drift: 35.2%, excess USD = 35.2% of $2100 = $739.2
     // Half excess in ETH = $369.6 / $2000 = 0.1848 ETH
     const balances = makeBalances("1", "200");
     const strategy = makeRebalanceStrategy();
     const result = evaluateRebalance(strategy, MARKET_DATA, balances);
-    expect(result.decision).toBe("transfer");
-    expect(result.transfer).toBeDefined();
-    expect(result.transfer!.amount).toBeGreaterThan(0);
-    expect(result.transfer!.amount).toBeLessThan(1); // less than total balance
+    expect(result.decision).toBe("swap");
+    expect(result.swap).toBeDefined();
+    expect(result.swap!.amountIn).toBeGreaterThan(0);
+    expect(result.swap!.amountIn).toBeLessThan(1); // less than total balance
   });
 
-  it("does not transfer more than 90% of balance", () => {
+  it("does not swap more than 90% of balance", () => {
     // Extreme case: almost all value in ETH
     const balances = makeBalances("10", "1");
     const strategy = makeRebalanceStrategy();
     const result = evaluateRebalance(strategy, MARKET_DATA, balances);
-    if (result.decision === "transfer" && result.transfer) {
-      expect(result.transfer.amount).toBeLessThanOrEqual(10 * 0.9);
+    if (result.decision === "swap" && result.swap) {
+      expect(result.swap.amountIn).toBeLessThanOrEqual(10 * 0.9);
     }
+  });
+
+  it("includes correct token addresses in swap decision", () => {
+    const balances = makeBalances("1", "200");
+    const strategy = makeRebalanceStrategy();
+    const result = evaluateRebalance(strategy, MARKET_DATA, balances);
+    expect(result.decision).toBe("swap");
+    expect(result.swap!.tokenIn).toBe(SWAP_TOKENS["ethereum-sepolia"]["WETH"]);
+    expect(result.swap!.tokenOut).toBe(SWAP_TOKENS["ethereum-sepolia"]["USDT"]);
+    expect(result.swap!.chain).toBe("ethereum-sepolia");
+  });
+
+  it("uses MATIC swap tokens when polygon is overweight", () => {
+    // MATIC: 10000 * 0.5 = $5000 (96.2%), ETH: 0.01 * 2000 = $20 (3.8%)
+    const balances = makeBalances("0.01", "10000");
+    const strategy = makeRebalanceStrategy();
+    const result = evaluateRebalance(strategy, MARKET_DATA, balances);
+    expect(result.decision).toBe("swap");
+    expect(result.swap!.tokenInSymbol).toBe("MATIC");
+    expect(result.swap!.tokenIn).toBe(SWAP_TOKENS["polygon-amoy"]["WMATIC"]);
+    expect(result.swap!.chain).toBe("polygon-amoy");
   });
 });
 

--- a/tests/agent/swap.test.ts
+++ b/tests/agent/swap.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { quoteSwap, executeSwap, SWAP_TOKENS } from "@/lib/wdk/swap";
+
+const mockQuoteSwapFn = vi.fn();
+const mockSwapFn = vi.fn();
+
+vi.mock("@/lib/wdk/wallet", () => ({
+  getWdk: vi.fn(),
+}));
+
+vi.mock("@tetherto/wdk-protocol-swap-velora-evm", async () => {
+  return {
+    default: class MockVelora {
+      quoteSwap(...args: unknown[]) { return mockQuoteSwapFn(...args); }
+      swap(...args: unknown[]) { return mockSwapFn(...args); }
+    },
+  };
+});
+
+import { getWdk } from "@/lib/wdk/wallet";
+const mockGetWdkFn = vi.mocked(getWdk);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ============================================================
+// SWAP_TOKENS config
+// ============================================================
+
+describe("SWAP_TOKENS", () => {
+  it("has token addresses for ethereum-sepolia", () => {
+    expect(SWAP_TOKENS["ethereum-sepolia"]).toBeDefined();
+    expect(SWAP_TOKENS["ethereum-sepolia"]["WETH"]).toMatch(/^0x/);
+    expect(SWAP_TOKENS["ethereum-sepolia"]["USDT"]).toMatch(/^0x/);
+  });
+
+  it("has token addresses for polygon-amoy", () => {
+    expect(SWAP_TOKENS["polygon-amoy"]).toBeDefined();
+    expect(SWAP_TOKENS["polygon-amoy"]["WMATIC"]).toMatch(/^0x/);
+    expect(SWAP_TOKENS["polygon-amoy"]["USDT"]).toMatch(/^0x/);
+  });
+});
+
+// ============================================================
+// quoteSwap
+// ============================================================
+
+describe("quoteSwap", () => {
+  const mockQuoteResult = {
+    fee: 50000000000000n,
+    tokenInAmount: 1000000000000000000n,
+    tokenOutAmount: 2000000000n,
+  };
+
+  function setupWdk() {
+    const mockAccount = { getAddress: vi.fn().mockResolvedValue("0xabc") };
+    const mockWdk = { getAccount: vi.fn().mockResolvedValue(mockAccount) };
+    mockGetWdkFn.mockReturnValue(mockWdk as any);
+    mockQuoteSwapFn.mockResolvedValue(mockQuoteResult);
+    return mockWdk;
+  }
+
+  it("returns quote with correct shape", async () => {
+    setupWdk();
+
+    const quote = await quoteSwap({
+      chain: "ethereum-sepolia",
+      tokenIn: SWAP_TOKENS["ethereum-sepolia"]["WETH"],
+      tokenOut: SWAP_TOKENS["ethereum-sepolia"]["USDT"],
+      tokenInAmount: 1000000000000000000n,
+    });
+
+    expect(quote.fee).toBe("50000000000000");
+    expect(quote.tokenInAmount).toBe("1000000000000000000");
+    expect(quote.tokenOutAmount).toBe("2000000000");
+    expect(quote.chain).toBe("ethereum-sepolia");
+    expect(mockQuoteSwapFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses default chain when not specified", async () => {
+    const mockWdk = setupWdk();
+
+    await quoteSwap({
+      tokenIn: "0xTokenA",
+      tokenOut: "0xTokenB",
+      tokenInAmount: 100n,
+    });
+
+    expect(mockWdk.getAccount).toHaveBeenCalledWith("ethereum-sepolia", 0);
+  });
+
+  it("passes tokenOutAmount when tokenInAmount not specified", async () => {
+    setupWdk();
+
+    await quoteSwap({
+      tokenIn: "0xTokenA",
+      tokenOut: "0xTokenB",
+      tokenOutAmount: 500n,
+    });
+
+    expect(mockQuoteSwapFn).toHaveBeenCalledWith(
+      expect.objectContaining({ tokenOutAmount: 500n })
+    );
+  });
+
+  it("propagates errors from protocol", async () => {
+    setupWdk();
+    mockQuoteSwapFn.mockRejectedValue(new Error("No liquidity"));
+
+    await expect(
+      quoteSwap({
+        tokenIn: "0xA",
+        tokenOut: "0xB",
+        tokenInAmount: 100n,
+      })
+    ).rejects.toThrow("No liquidity");
+  });
+});
+
+// ============================================================
+// executeSwap
+// ============================================================
+
+describe("executeSwap", () => {
+  const mockSwapResult = {
+    hash: "0xswaphash123",
+    fee: 75000000000000n,
+    tokenInAmount: 1000000000000000000n,
+    tokenOutAmount: 1950000000n,
+  };
+
+  function setupWdk() {
+    const mockAccount = { getAddress: vi.fn().mockResolvedValue("0xabc") };
+    const mockWdk = { getAccount: vi.fn().mockResolvedValue(mockAccount) };
+    mockGetWdkFn.mockReturnValue(mockWdk as any);
+    mockSwapFn.mockResolvedValue(mockSwapResult);
+  }
+
+  it("returns execution result with hash", async () => {
+    setupWdk();
+
+    const result = await executeSwap({
+      chain: "ethereum-sepolia",
+      tokenIn: SWAP_TOKENS["ethereum-sepolia"]["WETH"],
+      tokenOut: SWAP_TOKENS["ethereum-sepolia"]["USDT"],
+      tokenInAmount: 1000000000000000000n,
+    });
+
+    expect(result.hash).toBe("0xswaphash123");
+    expect(result.fee).toBe("75000000000000");
+    expect(result.chain).toBe("ethereum-sepolia");
+  });
+
+  it("propagates errors from protocol", async () => {
+    setupWdk();
+    mockSwapFn.mockRejectedValue(new Error("Insufficient balance"));
+
+    await expect(
+      executeSwap({
+        tokenIn: "0xA",
+        tokenOut: "0xB",
+        tokenInAmount: 100n,
+      })
+    ).rejects.toThrow("Insufficient balance");
+  });
+});


### PR DESCRIPTION
## Summary
- Integrate `@tetherto/wdk-protocol-swap-velora-evm` — rebalance strategy now proposes real DEX swaps (ETH/MATIC → USDT) via Velora instead of vault transfers
- Agent fetches real `quoteSwap` data from Velora DEX before governance evaluation
- Swap decisions go through full 4-layer governance pipeline (rules → anomaly → LLM → human)
- 121 tests (was 111), build clean

## Files changed
- **New:** `src/lib/wdk/swap.ts` — Velora wrapper (`quoteSwap`, `executeSwap`, token addresses)
- **New:** `tests/agent/swap.test.ts` — 8 tests for swap wrapper
- **Modified:** strategies.ts (swap decisions), autonomous.ts (swap handling in agent cycle), types (AgentRunDecision includes "swap")

## Why this matters vs competition
Tsentry does swaps with raw ethers.js bypassing governance. We route swaps through the 4-layer pipeline — the agent proposes, stats validate, LLM explains, human approves.

## Test plan
- [x] 121 tests pass (`npm test`)
- [x] Build clean (`npm run build`)
- [x] Rebalance tests verify swap decision with correct token addresses
- [x] Swap wrapper tests verify quote/execute with mocked WDK
- [ ] Manual: run demo mode, verify swap decisions appear in agent logs

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)